### PR TITLE
path correction for including Psr\Log files

### DIFF
--- a/AmazonPay/Client.php
+++ b/AmazonPay/Client.php
@@ -12,11 +12,11 @@ require_once 'HttpCurl.php';
 require_once 'ClientInterface.php';
 require_once 'Regions.php';
 if (!interface_exists('\Psr\Log\LoggerAwareInterface')) {
-    require_once('Psr/Log/LoggerAwareInterface.php');
+    require_once(__DIR__.'/../Psr/Log/LoggerAwareInterface.php');
 }
 
 if (!interface_exists('\Psr\Log\LoggerInterface')) {
-    require_once('Psr/Log/LoggerInterface.php');
+    require_once(__DIR__.'/../Psr/Log/LoggerInterface.php');
 }
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;

--- a/AmazonPay/IpnHandler.php
+++ b/AmazonPay/IpnHandler.php
@@ -9,10 +9,10 @@ namespace AmazonPay;
 require_once 'HttpCurl.php';
 require_once 'IpnHandlerInterface.php';
 if (!interface_exists('\Psr\Log\LoggerAwareInterface')) {
-    require_once('Psr/Log/LoggerAwareInterface.php');
+    require_once(__DIR__.'/../Psr/Log/LoggerAwareInterface.php');
 }
 if (!interface_exists('\Psr\Log\LoggerInterface')) {
-    require_once('Psr/Log/LoggerInterface.php');
+    require_once(__DIR__.'/../Psr/Log/LoggerInterface.php');
 }
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;


### PR DESCRIPTION
The relative file paths for including the Psr\Log interface files did not work in unmodified environments without adding the sdk directory to the allowed include paths. Thus the SDK was not usable out of the box.

**Original Error:**
Fatal error: require_once(): Failed opening required 'Psr/Log/LoggerAwareInterface.php' (include_path='.:/usr/share/php:/usr/share/pear')