### PR TITLE
Fix undefined index error

### DIFF
--- a/AmazonPay/Client.php
+++ b/AmazonPay/Client.php
@@ -779,7 +779,7 @@ class Client implements ClientInterface, LoggerAwareInterface
             'mws_auth_token'            => 'MWSAuthToken'
         );
 
-        if ($requestParameters['authorization_amount'] && !$requestParameters['currency_code']) {
+        if (isset($requestParameters['authorization_amount']) && !isset($requestParameters['currency_code'])) {
             $requestParameters['currency_code'] = strtoupper($this->config['currency_code']);
         }
 


### PR DESCRIPTION
checking the authorization_amount causes a PHP Undefined Index-error if you do not set an authorization_amount

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
