### PR TITLE
Corrected short identifier for license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
       "amazon pay"
    ],
    "homepage": "https://github.com/amzn/amazon-pay-sdk-php",
-   "license": "Apache OSL-2",
+   "license": "Apache-2",
    "authors": [
       {
          "name": "Amazon Pay SDK",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The license text appears to be Apache License 2.0.
The short identifier used does not appear to be defined, but nearly correct for the license.

See: https://getcomposer.org/doc/04-schema.md#license


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
